### PR TITLE
Extract class TypeCatalog fixing bug

### DIFF
--- a/src/Api/Factory/ServiceApiFactory.php
+++ b/src/Api/Factory/ServiceApiFactory.php
@@ -16,6 +16,7 @@
 namespace Katana\Sdk\Api\Factory;
 
 use Katana\Sdk\Api\ActionApi;
+use Katana\Sdk\Api\TypeCatalog;
 use Katana\Sdk\Console\CliInput;
 use Katana\Sdk\Mapper\CompactTransportMapper;
 use Katana\Sdk\Messaging\MessagePackSerializer;
@@ -68,6 +69,7 @@ class ServiceApiFactory extends ApiFactory
             $action,
             $caller,
             $this->mapper->getTransport($data),
+            new TypeCatalog(),
             $this->mapper->getParams($data)
         );
     }

--- a/src/Api/TypeCatalog.php
+++ b/src/Api/TypeCatalog.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * PHP 5 SDK for the KATANA(tm) Framework (http://katana.kusanagi.io)
+ * Copyright (c) 2016-2017 KUSANAGI S.L. All rights reserved.
+ *
+ * Distributed under the MIT license
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ *
+ * @link      https://github.com/kusanagi/katana-sdk-php5
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2016-2017 KUSANAGI S.L. (http://kusanagi.io)
+ */
+
+namespace Katana\Sdk\Api;
+
+use Katana\Sdk\Exception\InvalidValueException;
+
+/**
+ * Contains the available types in the API.
+ * @package Katana\Sdk\Api
+ */
+class TypeCatalog
+{
+    const TYPE_NULL    = 'null';
+    const TYPE_BOOLEAN = 'boolean';
+    const TYPE_INTEGER = 'integer';
+    const TYPE_FLOAT   = 'float';
+    const TYPE_STRING  = 'string';
+    const TYPE_ARRAY   = 'array';
+    const TYPE_OBJECT  = 'object';
+
+    /**
+     * @param array $value
+     * @return bool
+     */
+    private function isArrayType(array $value)
+    {
+        if ($value === []) {
+            return true;
+        }
+        return array_keys($value) === range(0, count($value) -1);
+    }
+
+    /**
+     * @param array $value
+     * @return bool
+     */
+    private function isObjectType(array $value)
+    {
+        return count(array_filter(array_keys($value), 'is_string')) === count($value);
+    }
+
+    /**
+     * Return the default value for a given type.
+     *
+     * @param string $type
+     * @return mixed
+     * @throws InvalidValueException
+     */
+    public function getDefault($type)
+    {
+        switch ($type) {
+            case self::TYPE_NULL:
+                return null;
+            case self::TYPE_BOOLEAN:
+                return false;
+            case self::TYPE_INTEGER:
+            case self::TYPE_FLOAT:
+                return 0;
+            case self::TYPE_STRING:
+                return '';
+            case self::TYPE_ARRAY:
+            case self::TYPE_OBJECT:
+                return [];
+        }
+
+        throw new InvalidValueException("Invalid value type: $type");
+    }
+
+    /**
+     * Validates a value against a type.
+     *
+     * @param mixed $value
+     * @param string $type
+     * @return bool
+     * @throws InvalidValueException
+     */
+    public function validate($type, $value)
+    {
+        switch ($type) {
+            case self::TYPE_NULL:
+                return is_null($value);
+            case self::TYPE_BOOLEAN:
+                return is_bool($value);
+            case self::TYPE_INTEGER:
+                return is_integer($value);
+            case self::TYPE_FLOAT:
+                return is_float($value);
+            case self::TYPE_STRING:
+                return is_string($value);
+            case self::TYPE_ARRAY:
+                if (!is_array($value)) {
+                    return false;
+                }
+                return $this->isArrayType($value);
+            case self::TYPE_OBJECT:
+                if (!is_array($value)) {
+                    return false;
+                }
+                return $this->isObjectType($value);
+        }
+
+        throw new InvalidValueException("Invalid value type: $type");
+    }
+}

--- a/tests/Api/ActionApiTest.php
+++ b/tests/Api/ActionApiTest.php
@@ -20,6 +20,7 @@ use Katana\Sdk\Api\DeferCall;
 use Katana\Sdk\Api\File;
 use Katana\Sdk\Api\Transport;
 use Katana\Sdk\Api\TransportMeta;
+use Katana\Sdk\Api\TypeCatalog;
 use Katana\Sdk\Component\Component;
 use Katana\Sdk\Exception\InvalidValueException;
 use Katana\Sdk\Logger\KatanaLogger;
@@ -83,7 +84,8 @@ class ActionApiTest extends \PHPUnit_Framework_TestCase
             true,
             'action',
             $caller->reveal(),
-            $this->transport->reveal()
+            $this->transport->reveal(),
+            new TypeCatalog()
         );
     }
 

--- a/tests/Api/TypeCatalogTest.php
+++ b/tests/Api/TypeCatalogTest.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * PHP 7 SDK for the KATANA(tm) Framework (http://katana.kusanagi.io)
+ * Copyright (c) 2016-2017 KUSANAGI S.L. All rights reserved.
+ *
+ * Distributed under the MIT license
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code
+ *
+ * @link      https://github.com/kusanagi/katana-sdk-php7
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) 2016-2017 KUSANAGI S.L. (http://kusanagi.io)
+ */
+
+namespace Katana\Sdk\Tests\Api;
+
+use Katana\Sdk\Api\TypeCatalog;
+
+class TypeCatalogTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var TypeCatalog
+     */
+    private $typeCatalog;
+
+    public function setUp()
+    {
+        $this->typeCatalog = new TypeCatalog();
+    }
+
+    public function testNullDefault()
+    {
+        $this->assertNull(
+            $this->typeCatalog->getDefault(TypeCatalog::TYPE_NULL)
+        );
+    }
+
+    public function testBooleanDefault()
+    {
+        $this->assertFalse(
+            $this->typeCatalog->getDefault(TypeCatalog::TYPE_BOOLEAN)
+        );
+    }
+
+    public function testIntegerDefault()
+    {
+        $this->assertEquals(
+            0,
+            $this->typeCatalog->getDefault(TypeCatalog::TYPE_INTEGER)
+        );
+    }
+
+    public function testFloatDefault()
+    {
+        $this->assertEquals(
+            0,
+            $this->typeCatalog->getDefault(TypeCatalog::TYPE_FLOAT)
+        );
+    }
+
+    public function testStringDefault()
+    {
+        $this->assertEquals(
+            '',
+            $this->typeCatalog->getDefault(TypeCatalog::TYPE_STRING)
+        );
+    }
+
+    public function testArrayDefault()
+    {
+        $this->assertEquals(
+            [],
+            $this->typeCatalog->getDefault(TypeCatalog::TYPE_ARRAY)
+        );
+    }
+
+    public function testObjectDefault()
+    {
+        $this->assertEquals(
+            [],
+            $this->typeCatalog->getDefault(TypeCatalog::TYPE_OBJECT)
+        );
+    }
+
+    public function validateDataProvider()
+    {
+        return [
+            // Type Null
+            [true, TypeCatalog::TYPE_NULL, null],
+            [false, TypeCatalog::TYPE_NULL, false],
+            [false, TypeCatalog::TYPE_NULL, true],
+            [false, TypeCatalog::TYPE_NULL, 0],
+            [false, TypeCatalog::TYPE_NULL, 42],
+            [false, TypeCatalog::TYPE_NULL, 0.0],
+            [false, TypeCatalog::TYPE_NULL, 3.1416],
+            [false, TypeCatalog::TYPE_NULL, ''],
+            [false, TypeCatalog::TYPE_NULL, 'foo'],
+            [false, TypeCatalog::TYPE_NULL, []],
+            [false, TypeCatalog::TYPE_NULL, ['a', 'b', 'c']],
+            [false, TypeCatalog::TYPE_NULL, ['a' => 1, 'b' => 2]],
+            // Type Boolean
+            [false, TypeCatalog::TYPE_BOOLEAN, null],
+            [true, TypeCatalog::TYPE_BOOLEAN, false],
+            [true, TypeCatalog::TYPE_BOOLEAN, true],
+            [false, TypeCatalog::TYPE_BOOLEAN, 0],
+            [false, TypeCatalog::TYPE_BOOLEAN, 42],
+            [false, TypeCatalog::TYPE_BOOLEAN, 0.0],
+            [false, TypeCatalog::TYPE_BOOLEAN, 3.1416],
+            [false, TypeCatalog::TYPE_BOOLEAN, ''],
+            [false, TypeCatalog::TYPE_BOOLEAN, 'foo'],
+            [false, TypeCatalog::TYPE_BOOLEAN, []],
+            [false, TypeCatalog::TYPE_BOOLEAN, ['a', 'b', 'c']],
+            [false, TypeCatalog::TYPE_BOOLEAN, ['a' => 1, 'b' => 2]],
+            // Type Integer
+            [false, TypeCatalog::TYPE_INTEGER, null],
+            [false, TypeCatalog::TYPE_INTEGER, false],
+            [false, TypeCatalog::TYPE_INTEGER, true],
+            [true, TypeCatalog::TYPE_INTEGER, 0],
+            [true, TypeCatalog::TYPE_INTEGER, 42],
+            [false, TypeCatalog::TYPE_INTEGER, 0.0],
+            [false, TypeCatalog::TYPE_INTEGER, 3.1416],
+            [false, TypeCatalog::TYPE_INTEGER, ''],
+            [false, TypeCatalog::TYPE_INTEGER, 'foo'],
+            [false, TypeCatalog::TYPE_INTEGER, []],
+            [false, TypeCatalog::TYPE_INTEGER, ['a', 'b', 'c']],
+            [false, TypeCatalog::TYPE_INTEGER, ['a' => 1, 'b' => 2]],
+            // Type Float
+            [false, TypeCatalog::TYPE_FLOAT, null],
+            [false, TypeCatalog::TYPE_FLOAT, false],
+            [false, TypeCatalog::TYPE_FLOAT, true],
+            [false, TypeCatalog::TYPE_FLOAT, 0],
+            [false, TypeCatalog::TYPE_FLOAT, 42],
+            [true, TypeCatalog::TYPE_FLOAT, 0.0],
+            [true, TypeCatalog::TYPE_FLOAT, 3.1416],
+            [false, TypeCatalog::TYPE_FLOAT, ''],
+            [false, TypeCatalog::TYPE_FLOAT, 'foo'],
+            [false, TypeCatalog::TYPE_FLOAT, []],
+            [false, TypeCatalog::TYPE_FLOAT, ['a', 'b', 'c']],
+            [false, TypeCatalog::TYPE_FLOAT, ['a' => 1, 'b' => 2]],
+            // Type String
+            [false, TypeCatalog::TYPE_STRING, null],
+            [false, TypeCatalog::TYPE_STRING, false],
+            [false, TypeCatalog::TYPE_STRING, true],
+            [false, TypeCatalog::TYPE_STRING, 0],
+            [false, TypeCatalog::TYPE_STRING, 42],
+            [false, TypeCatalog::TYPE_STRING, 0.0],
+            [false, TypeCatalog::TYPE_STRING, 3.1416],
+            [true, TypeCatalog::TYPE_STRING, ''],
+            [true, TypeCatalog::TYPE_STRING, 'foo'],
+            [false, TypeCatalog::TYPE_STRING, []],
+            [false, TypeCatalog::TYPE_STRING, ['a', 'b', 'c']],
+            [false, TypeCatalog::TYPE_STRING, ['a' => 1, 'b' => 2]],
+            // Type Array
+            [false, TypeCatalog::TYPE_ARRAY, null],
+            [false, TypeCatalog::TYPE_ARRAY, false],
+            [false, TypeCatalog::TYPE_ARRAY, true],
+            [false, TypeCatalog::TYPE_ARRAY, 0],
+            [false, TypeCatalog::TYPE_ARRAY, 42],
+            [false, TypeCatalog::TYPE_ARRAY, 0.0],
+            [false, TypeCatalog::TYPE_ARRAY, 3.1416],
+            [false, TypeCatalog::TYPE_ARRAY, ''],
+            [false, TypeCatalog::TYPE_ARRAY, 'foo'],
+            [true, TypeCatalog::TYPE_ARRAY, []],
+            [true, TypeCatalog::TYPE_ARRAY, ['a', 'b', 'c']],
+            [false, TypeCatalog::TYPE_ARRAY, ['a' => 1, 'b' => 2]],
+            // Type Object
+            [false, TypeCatalog::TYPE_OBJECT, null],
+            [false, TypeCatalog::TYPE_OBJECT, false],
+            [false, TypeCatalog::TYPE_OBJECT, true],
+            [false, TypeCatalog::TYPE_OBJECT, 0],
+            [false, TypeCatalog::TYPE_OBJECT, 42],
+            [false, TypeCatalog::TYPE_OBJECT, 0.0],
+            [false, TypeCatalog::TYPE_OBJECT, 3.1416],
+            [false, TypeCatalog::TYPE_OBJECT, ''],
+            [false, TypeCatalog::TYPE_OBJECT, 'foo'],
+            [true, TypeCatalog::TYPE_OBJECT, []],
+            [false, TypeCatalog::TYPE_OBJECT, ['a', 'b', 'c']],
+            [true, TypeCatalog::TYPE_OBJECT, ['a' => 1, 'b' => 2]],
+        ];
+    }
+
+    /**
+     * @dataProvider validateDataProvider
+     */
+    public function testValidateNullType($expected, $type, $value)
+    {
+        $this->assertEquals(
+            $expected,
+            $this->typeCatalog->validate($type, $value)
+        );
+    }
+}


### PR DESCRIPTION
Refactor to extract a TypeCatalog class which holds the API defined types and logic to validate and generate default values.

It also fixes a type validation bug in which an empty collection is considered invalid.